### PR TITLE
Add the option to reject dateless coverage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,10 @@
 				<hr />
 			</div>
 
+			<Checkbox v-model:checked="settings.rejectDateless" label="Reject locations without date" />
+			<small>This will prevent the local business tripod coverage that doesn't have a date.</small>
+			<hr />
+
 			<Checkbox v-model:checked="settings.adjustHeading" label="Adjust heading" />
 			<div v-if="settings.adjustHeading" class="indent">
 				<label class="flex wrap">
@@ -140,6 +144,7 @@ const settings = reactive({
 	radius: 500,
 	rejectUnofficial: true,
 	rejectNoDescription: true,
+	rejectDateless: true,
 	adjustHeading: true,
 	headingDeviation: 0,
 	adjustPitch: true,

--- a/src/utils/SVreq.js
+++ b/src/utils/SVreq.js
@@ -9,6 +9,7 @@ export default function SVreq(loc, settings) {
 				if (settings.rejectNoDescription && !res.location.description && !res.location.shortDescription) return reject();
 				if (settings.getIntersection && res.links.length < 3) return reject();
 			}
+			if (settings.rejectDateless && !res.imageDate) return reject();
 			if (Date.parse(res.imageDate) < Date.parse(settings.fromDate) || Date.parse(res.imageDate) > Date.parse(settings.toDate)) return reject();
 			if (settings.adjustHeading && res.links.length > 0) {
 				loc.heading = parseInt(res.links[0].heading) + randomInRange(-settings.headingDeviation, settings.headingDeviation);


### PR DESCRIPTION
Coverage without a date (such as https://goo.gl/maps/BVTcpkYpVEWme3oR6 ) would always get treated as within the date range. Added an option to avoid coverage like this